### PR TITLE
Add Pick Insights Studio dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
-# Testing123
+# Pick Insights Studio
+
+Pick Insights Studio is a lightweight web dashboard for consolidating betting
+intel from every expert source you trust. Log each matchup, capture the voices
+that influenced your card, and see consensus at a glance with auto-generated
+breakdowns.
+
+## Features
+
+- **Flexible slate builder** – track any matchup with kickoff times, custom tags,
+  and running notes.
+- **Source library** – maintain a list of trusted experts, podcasts, models, or
+  beat reporters that you can reuse across games.
+- **Pick tracking** – add as many predictions as you need per game, including
+  notes and confidence percentages.
+- **Consensus visuals** – automatically compute pick counts, average confidence,
+  and a consensus meter that highlights agreement strength.
+- **Import/export** – snapshot the entire setup to share or back up, then reload
+  it later.
+- **Local-first** – everything is stored in your browser via `localStorage`, so
+  no accounts or databases are required.
+
+## Getting Started
+
+1. Launch a static file server from the project root:
+
+   ```bash
+   cd dashboard
+   python -m http.server 8000
+   ```
+
+2. Open `http://localhost:8000` in your browser to start organizing your slate.
+
+> 💡 The tool ships with a small amount of sample data so you can see how the
+> workflow feels. Use the archive/delete buttons on each card to prune it down
+> to only the games you care about.
+
+## Export Format
+
+Exported files include every saved source and matchup. They can be versioned or
+shared with league mates, then re-imported via the **Import Setup** control in
+the header. The schema is:
+
+```json
+{
+  "sources": [
+    {
+      "name": "string",
+      "type": "string",
+      "url": "string"
+    }
+  ],
+  "games": [
+    {
+      "name": "string",
+      "kickoff": "ISO date",
+      "tags": ["string"],
+      "notes": "string",
+      "archived": false,
+      "picks": [
+        {
+          "source": "string",
+          "choice": "string",
+          "confidence": "0-100",
+          "notes": "string"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Imported files generate fresh identifiers to keep existing data intact. If an
+import fails, double-check that the JSON aligns with this structure.

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,0 +1,527 @@
+const storageKey = 'pick-insights-studio';
+
+const defaultState = {
+  sources: [
+    {
+      id: crypto.randomUUID(),
+      name: 'Sharp Football Analysis',
+      type: 'Model',
+      url: 'https://www.sharpfootballanalysis.com/'
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'The Ringer Gambling Show',
+      type: 'Podcast',
+      url: 'https://www.theringer.com/podcasts'
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'PFF Forecast',
+      type: 'Analytics',
+      url: 'https://www.pff.com/podcasts/the-forecast'
+    }
+  ],
+  games: [
+    {
+      id: crypto.randomUUID(),
+      name: 'Lions @ Packers',
+      kickoff: '',
+      tags: ['Divisional', 'Primetime'],
+      notes: 'Monitor weather at Lambeau and offensive line injuries.',
+      archived: false,
+      picks: [
+        {
+          id: crypto.randomUUID(),
+          source: 'Sharp Football Analysis',
+          choice: 'Lions -2.5',
+          confidence: 68,
+          notes: 'Edge in EPA/play and explosive plays.'
+        },
+        {
+          id: crypto.randomUUID(),
+          source: 'PFF Forecast',
+          choice: 'Packers +2.5',
+          confidence: 60,
+          notes: 'Numbers show value on the home dog.'
+        }
+      ]
+    }
+  ]
+};
+
+const state = loadState();
+
+const elements = {
+  gamesContainer: document.querySelector('#gamesContainer'),
+  gameTemplate: document.querySelector('#gameTemplate'),
+  pickRowTemplate: document.querySelector('#pickRowTemplate'),
+  addGameForm: document.querySelector('#addGameForm'),
+  gameNameInput: document.querySelector('#gameNameInput'),
+  gameTimeInput: document.querySelector('#gameTimeInput'),
+  gameTagsInput: document.querySelector('#gameTagsInput'),
+  gameNotesInput: document.querySelector('#gameNotesInput'),
+  addSourceForm: document.querySelector('#addSourceForm'),
+  sourceNameInput: document.querySelector('#sourceNameInput'),
+  sourceTypeInput: document.querySelector('#sourceTypeInput'),
+  sourceUrlInput: document.querySelector('#sourceUrlInput'),
+  sourceList: document.querySelector('#sourceList'),
+  sourceOptions: document.querySelector('#sourceOptions'),
+  exportButton: document.querySelector('#exportButton'),
+  importInput: document.querySelector('#importInput')
+};
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) {
+      return structuredClone(defaultState);
+    }
+    const parsed = JSON.parse(raw);
+    parsed.sources ??= [];
+    parsed.games ??= [];
+    parsed.games.forEach((game) => {
+      game.picks ??= [];
+      game.tags = Array.isArray(game.tags)
+        ? game.tags
+        : (game.tags || '')
+            .split(',')
+            .map((tag) => tag.trim())
+            .filter(Boolean);
+    });
+    return parsed;
+  } catch (error) {
+    console.error('Failed to parse state, falling back to defaults', error);
+    return structuredClone(defaultState);
+  }
+}
+
+function saveState() {
+  localStorage.setItem(storageKey, JSON.stringify(state));
+}
+
+function render() {
+  renderSources();
+  renderGames();
+}
+
+function renderSources() {
+  elements.sourceList.innerHTML = '';
+  elements.sourceOptions.innerHTML = '';
+
+  if (!state.sources.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'Add the podcasts, models, and insiders you trust.';
+    elements.sourceList.append(empty);
+  }
+
+  state.sources.forEach((source) => {
+    const option = document.createElement('option');
+    option.value = source.name;
+    elements.sourceOptions.append(option);
+
+    const chip = document.createElement('div');
+    chip.className = 'source-chip';
+
+    const name = document.createElement('div');
+    name.className = 'source-chip__name';
+    name.textContent = source.name;
+    chip.append(name);
+
+    const meta = document.createElement('div');
+    meta.className = 'source-chip__meta';
+    if (source.type) {
+      const type = document.createElement('span');
+      type.textContent = source.type;
+      meta.append(type);
+    }
+    if (source.url) {
+      const link = document.createElement('a');
+      link.href = source.url;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = 'Visit';
+      meta.append(link);
+    }
+    if (meta.childElementCount) {
+      chip.append(meta);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'source-chip__actions';
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'ghost-button ghost-button--danger';
+    removeButton.textContent = 'Remove';
+    removeButton.addEventListener('click', () => {
+      state.sources = state.sources.filter((item) => item.id !== source.id);
+      saveState();
+      render();
+    });
+    actions.append(removeButton);
+    chip.append(actions);
+
+    elements.sourceList.append(chip);
+  });
+}
+
+function renderGames() {
+  elements.gamesContainer.innerHTML = '';
+
+  if (!state.games.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'No games yet. Add your first matchup to get started!';
+    elements.gamesContainer.append(empty);
+    return;
+  }
+
+  state.games.forEach((game) => {
+    const clone = elements.gameTemplate.content.cloneNode(true);
+    const card = clone.querySelector('.game-card');
+    const title = clone.querySelector('.game-card__title');
+    const meta = clone.querySelector('.game-card__meta');
+    const tbody = clone.querySelector('tbody');
+    const addRowButton = clone.querySelector('.js-add-row');
+    const duplicateButton = clone.querySelector('.js-duplicate');
+    const archiveButton = clone.querySelector('.js-archive');
+    const deleteButton = clone.querySelector('.js-delete');
+    const meterBar = clone.querySelector('.meter__bar');
+    const meterLabel = clone.querySelector('.meter__label');
+    const breakdown = clone.querySelector('.breakdown');
+    const notesArea = clone.querySelector('.game-notes');
+
+    card.dataset.id = game.id;
+    if (game.archived) {
+      card.classList.add('game-card--archived');
+    }
+
+    title.textContent = game.name;
+    const metaParts = [];
+    if (game.kickoff) {
+      metaParts.push(new Date(game.kickoff).toLocaleString());
+    }
+    if (game.tags?.length) {
+      const tags = document.createElement('div');
+      tags.className = 'tag-list';
+      game.tags.forEach((tag) => {
+        const badge = document.createElement('span');
+        badge.className = 'tag';
+        badge.textContent = tag;
+        tags.append(badge);
+      });
+      meta.append(tags);
+    }
+    meta.prepend(metaParts.join(' • '));
+
+    notesArea.value = game.notes || '';
+    notesArea.addEventListener('input', (event) => {
+      game.notes = event.target.value;
+      saveState();
+    });
+
+    const renderRows = () => {
+      tbody.innerHTML = '';
+      game.picks.forEach((pick) => {
+        const row = elements.pickRowTemplate.content.cloneNode(true);
+        const sourceInput = row.querySelector('.pick-source');
+        const choiceInput = row.querySelector('.pick-choice');
+        const confidenceInput = row.querySelector('.pick-confidence');
+        const notesInput = row.querySelector('.pick-notes');
+        const removeButton = row.querySelector('.js-remove-row');
+
+        sourceInput.value = pick.source || '';
+        choiceInput.value = pick.choice || '';
+        confidenceInput.value = pick.confidence ?? '';
+        notesInput.value = pick.notes || '';
+
+        sourceInput.addEventListener('change', (event) => {
+          pick.source = event.target.value.trim();
+          maybeAddSource(pick.source);
+          saveState();
+          render();
+        });
+
+        choiceInput.addEventListener('input', (event) => {
+          pick.choice = event.target.value;
+          saveState();
+          refreshInsights();
+        });
+
+        confidenceInput.addEventListener('input', (event) => {
+          const value = event.target.value;
+          pick.confidence = value === '' ? '' : Math.max(0, Math.min(100, Number(value)));
+          saveState();
+          refreshInsights();
+        });
+
+        notesInput.addEventListener('input', (event) => {
+          pick.notes = event.target.value;
+          saveState();
+        });
+
+        removeButton.addEventListener('click', () => {
+          game.picks = game.picks.filter((item) => item.id !== pick.id);
+          saveState();
+          render();
+        });
+
+        tbody.append(row);
+      });
+
+      if (!game.picks.length) {
+        const emptyRow = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 5;
+        cell.className = 'empty-state';
+        cell.textContent = 'Add your first pick for this matchup!';
+        emptyRow.append(cell);
+        tbody.append(emptyRow);
+      }
+
+      refreshInsights();
+    };
+
+    const refreshInsights = () => {
+      const counts = new Map();
+      let totalConfidence = 0;
+      let confidenceEntries = 0;
+
+      game.picks.forEach((pick) => {
+        const key = pick.choice?.trim();
+        if (!key) return;
+
+        const data = counts.get(key) || {
+          total: 0,
+          confidence: 0,
+          notes: []
+        };
+        data.total += 1;
+        if (pick.confidence !== '' && !Number.isNaN(Number(pick.confidence))) {
+          data.confidence += Number(pick.confidence);
+          totalConfidence += Number(pick.confidence);
+          confidenceEntries += 1;
+        }
+        if (pick.source) {
+          data.notes.push({ source: pick.source, notes: pick.notes });
+        }
+        counts.set(key, data);
+      });
+
+      const totalPicks = Array.from(counts.values()).reduce((sum, item) => sum + item.total, 0);
+      const sorted = Array.from(counts.entries()).sort((a, b) => b[1].total - a[1].total);
+      const top = sorted[0];
+
+      const consensus = top ? Math.round((top[1].total / Math.max(totalPicks, 1)) * 100) : 0;
+      meterBar.style.width = `${consensus}%`;
+      meterLabel.textContent = top
+        ? `${consensus}% like ${top[0]} (${top[1].total} of ${totalPicks})`
+        : 'No picks logged yet';
+
+      breakdown.innerHTML = '';
+      if (!sorted.length) {
+        const empty = document.createElement('p');
+        empty.className = 'empty-state';
+        empty.textContent = 'Log picks to generate a breakdown.';
+        breakdown.append(empty);
+        return;
+      }
+
+      const maxCount = sorted[0][1].total;
+      sorted.forEach(([choice, info]) => {
+        const row = document.createElement('div');
+        row.className = 'breakdown-row';
+
+        const header = document.createElement('div');
+        header.className = 'breakdown-row__header';
+
+        const label = document.createElement('span');
+        label.className = 'breakdown-row__label';
+        label.textContent = choice;
+
+        const detail = document.createElement('span');
+        const avgConfidence = info.confidence && info.total
+          ? Math.round(info.confidence / info.total)
+          : '—';
+        detail.textContent = `${info.total} pick${info.total === 1 ? '' : 's'} · Avg conf: ${avgConfidence}`;
+
+        header.append(label, detail);
+        row.append(header);
+
+        const bar = document.createElement('div');
+        bar.className = 'breakdown-row__bar';
+        const fill = document.createElement('div');
+        fill.className = 'breakdown-row__fill';
+        fill.style.width = `${(info.total / maxCount) * 100}%`;
+        bar.append(fill);
+        row.append(bar);
+
+        if (info.notes.length) {
+          const notesList = document.createElement('ul');
+          notesList.className = 'breakdown-row__notes';
+          info.notes.forEach((note) => {
+            if (!note.notes) return;
+            const li = document.createElement('li');
+            li.textContent = `${note.source}: ${note.notes}`;
+            notesList.append(li);
+          });
+          if (notesList.childElementCount) {
+            row.append(notesList);
+          }
+        }
+
+        breakdown.append(row);
+      });
+    };
+
+    addRowButton.addEventListener('click', () => {
+      game.picks.push({
+        id: crypto.randomUUID(),
+        source: '',
+        choice: '',
+        confidence: '',
+        notes: ''
+      });
+      saveState();
+      renderRows();
+    });
+
+    duplicateButton.addEventListener('click', () => {
+      const copy = structuredClone(game);
+      copy.id = crypto.randomUUID();
+      copy.name = `${copy.name} (copy)`;
+      copy.picks = copy.picks.map((pick) => ({
+        ...pick,
+        id: crypto.randomUUID()
+      }));
+      state.games.push(copy);
+      saveState();
+      render();
+    });
+
+    archiveButton.addEventListener('click', () => {
+      game.archived = !game.archived;
+      archiveButton.textContent = game.archived ? 'Unarchive' : 'Archive';
+      saveState();
+      render();
+    });
+
+    archiveButton.textContent = game.archived ? 'Unarchive' : 'Archive';
+
+    deleteButton.addEventListener('click', () => {
+      if (!confirm(`Remove ${game.name}?`)) {
+        return;
+      }
+      state.games = state.games.filter((item) => item.id !== game.id);
+      saveState();
+      render();
+    });
+
+    renderRows();
+    elements.gamesContainer.append(clone);
+  });
+}
+
+function maybeAddSource(name) {
+  const trimmed = name?.trim();
+  if (!trimmed) return;
+  const exists = state.sources.some((item) => item.name.toLowerCase() === trimmed.toLowerCase());
+  if (exists) return;
+  state.sources.push({
+    id: crypto.randomUUID(),
+    name: trimmed,
+    type: '',
+    url: ''
+  });
+}
+
+elements.addGameForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const name = elements.gameNameInput.value.trim();
+  if (!name) return;
+  const kickoff = elements.gameTimeInput.value;
+  const tags = elements.gameTagsInput.value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+  const notes = elements.gameNotesInput.value.trim();
+
+  state.games.unshift({
+    id: crypto.randomUUID(),
+    name,
+    kickoff,
+    tags,
+    notes,
+    archived: false,
+    picks: []
+  });
+
+  saveState();
+  render();
+  event.target.reset();
+});
+
+elements.addSourceForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const name = elements.sourceNameInput.value.trim();
+  if (!name) return;
+  const type = elements.sourceTypeInput.value.trim();
+  const url = elements.sourceUrlInput.value.trim();
+
+  state.sources.push({
+    id: crypto.randomUUID(),
+    name,
+    type,
+    url
+  });
+
+  saveState();
+  render();
+  event.target.reset();
+});
+
+elements.exportButton.addEventListener('click', () => {
+  const exportBlob = new Blob([JSON.stringify(state, null, 2)], {
+    type: 'application/json'
+  });
+  const url = URL.createObjectURL(exportBlob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `pick-insights-${new Date().toISOString().slice(0, 10)}.json`;
+  anchor.click();
+  setTimeout(() => URL.revokeObjectURL(url), 500);
+});
+
+elements.importInput.addEventListener('change', async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+    if (!Array.isArray(parsed.games) || !Array.isArray(parsed.sources)) {
+      throw new Error('Invalid file format.');
+    }
+    parsed.games = parsed.games.map((game) => ({
+      ...game,
+      id: crypto.randomUUID(),
+      picks: (game.picks || []).map((pick) => ({
+        ...pick,
+        id: crypto.randomUUID()
+      }))
+    }));
+    parsed.sources = parsed.sources.map((source) => ({
+      ...source,
+      id: crypto.randomUUID()
+    }));
+    Object.assign(state, parsed);
+    saveState();
+    render();
+  } catch (error) {
+    console.error(error);
+    alert('Unable to import file. Ensure it was exported from this tool.');
+  } finally {
+    event.target.value = '';
+  }
+});
+
+render();

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pick Insights Studio</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="header-text">
+          <h1>Pick Insights Studio</h1>
+          <p>
+            Organize every expert pick, track consensus, and surface outliers at a
+            glance. Add games, layer in resources, and let the dashboard crunch
+            the numbers.
+          </p>
+        </div>
+        <div class="header-actions">
+          <button id="exportButton" class="ghost-button" type="button">
+            Export Setup
+          </button>
+          <label class="ghost-button" for="importInput">
+            Import Setup
+            <input id="importInput" type="file" accept="application/json" />
+          </label>
+        </div>
+      </header>
+
+      <main>
+        <section class="panel">
+          <h2>Build Your Slate</h2>
+          <form id="addGameForm" class="form-grid">
+            <label class="field">
+              <span>Matchup</span>
+              <input
+                id="gameNameInput"
+                type="text"
+                placeholder="E.g. Bills @ Chiefs"
+                required
+              />
+            </label>
+            <label class="field">
+              <span>Kickoff (optional)</span>
+              <input id="gameTimeInput" type="datetime-local" />
+            </label>
+            <label class="field field--wide">
+              <span>Tags (comma separated)</span>
+              <input id="gameTagsInput" type="text" placeholder="Primetime, Weather" />
+            </label>
+            <label class="field field--wide">
+              <span>Quick Notes</span>
+              <textarea
+                id="gameNotesInput"
+                placeholder="Key injuries, matchup context, betting trends..."
+                rows="2"
+              ></textarea>
+            </label>
+            <button class="primary" type="submit">Add Game</button>
+          </form>
+        </section>
+
+        <section class="panel">
+          <div class="panel-header">
+            <h2>Resource Library</h2>
+            <p>
+              Manage the expert voices you track. These appear as suggestions
+              when adding picks to any game.
+            </p>
+          </div>
+          <form id="addSourceForm" class="source-form">
+            <input id="sourceNameInput" type="text" placeholder="Resource name" />
+            <input
+              id="sourceTypeInput"
+              type="text"
+              placeholder="Type (podcast, model, beat writer...)"
+            />
+            <input id="sourceUrlInput" type="url" placeholder="Link (optional)" />
+            <button class="secondary" type="submit">Add Resource</button>
+          </form>
+          <div id="sourceList" class="source-list"></div>
+        </section>
+
+        <section id="gamesContainer" class="games-grid"></section>
+      </main>
+    </div>
+
+    <datalist id="sourceOptions"></datalist>
+
+    <template id="gameTemplate">
+      <article class="game-card">
+        <header class="game-card__header">
+          <div>
+            <h3 class="game-card__title"></h3>
+            <p class="game-card__meta"></p>
+          </div>
+          <div class="game-card__actions">
+            <button class="ghost-button js-duplicate">Duplicate</button>
+            <button class="ghost-button js-archive">Archive</button>
+            <button class="ghost-button ghost-button--danger js-delete">Delete</button>
+          </div>
+        </header>
+        <section class="game-card__body">
+          <div class="picks-table-wrapper">
+            <table class="picks-table">
+              <thead>
+                <tr>
+                  <th>Resource</th>
+                  <th>Pick</th>
+                  <th>Confidence</th>
+                  <th>Notes</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+            <button class="secondary js-add-row" type="button">Add Pick</button>
+          </div>
+          <aside class="game-card__insights">
+            <div class="insight-block">
+              <h4>Consensus Meter</h4>
+              <div class="meter">
+                <div class="meter__bar"></div>
+              </div>
+              <p class="meter__label"></p>
+            </div>
+            <div class="insight-block">
+              <h4>Pick Breakdown</h4>
+              <div class="breakdown"></div>
+            </div>
+            <div class="insight-block insight-block--notes">
+              <h4>Game Notes</h4>
+              <textarea class="game-notes"></textarea>
+            </div>
+          </aside>
+        </section>
+      </article>
+    </template>
+
+    <template id="pickRowTemplate">
+      <tr>
+        <td>
+          <input class="pick-source" list="sourceOptions" placeholder="Who" />
+        </td>
+        <td>
+          <input class="pick-choice" placeholder="Team or bet" />
+        </td>
+        <td>
+          <input class="pick-confidence" type="number" min="0" max="100" placeholder="%" />
+        </td>
+        <td>
+          <input class="pick-notes" placeholder="Angle or remark" />
+        </td>
+        <td>
+          <button class="ghost-button ghost-button--danger js-remove-row" type="button">
+            Remove
+          </button>
+        </td>
+      </tr>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -1,0 +1,429 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --panel: rgba(15, 23, 42, 0.75);
+  --panel-light: rgba(255, 255, 255, 0.08);
+  --surface: rgba(255, 255, 255, 0.06);
+  --border: rgba(148, 163, 184, 0.3);
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --danger: #f97316;
+  --font: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  background: linear-gradient(145deg, #020617 0%, #0b1223 45%, #1f2937 100%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+h1,
+ h2,
+ h3,
+ h4 {
+  margin: 0;
+  font-weight: 700;
+}
+
+p {
+  margin: 0;
+}
+
+button,
+ input,
+ textarea {
+  font-family: inherit;
+}
+
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.app-header {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.7);
+}
+
+.app-header h1 {
+  font-size: 2.5rem;
+  letter-spacing: -0.03em;
+}
+
+.header-text p {
+  color: var(--text-muted);
+  margin-top: 0.5rem;
+  max-width: 540px;
+  line-height: 1.6;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+main {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.panel-header h2 {
+  margin-bottom: 0.25rem;
+}
+
+.panel-header p {
+  color: var(--text-muted);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.field span {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.field--wide {
+  grid-column: 1 / -1;
+}
+
+input,
+ textarea,
+ select {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  color: var(--text);
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+input:focus,
+ textarea:focus,
+ select:focus {
+  outline: none;
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+textarea {
+  resize: vertical;
+}
+
+button {
+  cursor: pointer;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #0b1120;
+  padding: 0.85rem 1.6rem;
+  box-shadow: 0 10px 30px -12px var(--accent-strong);
+  justify-self: start;
+}
+
+.secondary {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text);
+  padding: 0.7rem 1.4rem;
+  border: 1px solid transparent;
+}
+
+.secondary:hover {
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.ghost-button {
+  background: transparent;
+  color: var(--text);
+  padding: 0.6rem 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.ghost-button input[type='file'] {
+  display: none;
+}
+
+.ghost-button--danger {
+  border-color: rgba(249, 115, 22, 0.35);
+  color: var(--danger);
+}
+
+.ghost-button:hover {
+  border-color: var(--accent);
+}
+
+.source-form {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.source-list {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.source-chip {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.source-chip__name {
+  font-weight: 600;
+}
+
+.source-chip__meta {
+  display: flex;
+  gap: 0.5rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.source-chip__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.games-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.game-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.game-card--archived::after {
+  content: 'Archived';
+  position: absolute;
+  top: 1.5rem;
+  right: -3rem;
+  transform: rotate(45deg);
+  background: rgba(148, 163, 184, 0.2);
+  color: rgba(226, 232, 240, 0.8);
+  padding: 0.35rem 3.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.2em;
+}
+
+.game-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.game-card__title {
+  font-size: 1.4rem;
+}
+
+.game-card__meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.game-card__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.game-card__body {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 1.5fr 1fr;
+}
+
+@media (max-width: 900px) {
+  .game-card__body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.picks-table-wrapper {
+  display: grid;
+  gap: 1rem;
+  background: var(--surface);
+  border-radius: 18px;
+  padding: 1.25rem;
+}
+
+.picks-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.picks-table th {
+  text-align: left;
+  padding-bottom: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.picks-table td {
+  padding: 0.4rem 0.4rem 0.4rem 0;
+}
+
+.picks-table input {
+  width: 100%;
+}
+
+.game-card__insights {
+  display: grid;
+  gap: 1rem;
+}
+
+.insight-block {
+  background: var(--surface);
+  border-radius: 18px;
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.insight-block--notes textarea {
+  min-height: 120px;
+}
+
+.meter {
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  overflow: hidden;
+  height: 12px;
+}
+
+.meter__bar {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  height: 100%;
+  width: 0%;
+  transition: width 0.4s ease;
+}
+
+.meter__label {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.breakdown {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.breakdown-row {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.breakdown-row__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.breakdown-row__label {
+  font-weight: 600;
+}
+
+.breakdown-row__bar {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.breakdown-row__fill {
+  height: 100%;
+  background: linear-gradient(135deg, #22d3ee 0%, #0284c7 100%);
+  width: 0;
+  transition: width 0.4s ease;
+}
+
+.empty-state {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.tag-list {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.tag {
+  background: rgba(59, 130, 246, 0.2);
+  color: #bfdbfe;
+  border-radius: 999px;
+  padding: 0.2rem 0.7rem;
+  font-size: 0.75rem;
+}
+
+.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- introduce Pick Insights Studio, a browser-based dashboard for organizing betting resources and matchup picks
- add reusable source library, flexible pick logging, consensus visuals, and import/export utilities powered by localStorage
- document setup steps and JSON export format in the README

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d5dc18dd488326b15d7a30149d9266